### PR TITLE
Feature/travis integrationtest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: node_js
 node_js:
   - "4.2"
+services: mongodb
+before_script:
+  - mongo use featureguardian
+script:
+  - npm install
+  - npm test
+  - mocha integration-test/bootstrap.test.js integration-test/*.test.js
 notifications:
   slack: featureguardian:ZbWTsXjCSfkOBLmoJtKw3psU

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "4.2"
 services: mongodb
 before_script:
-  - mongo use featureguardian
+  - mongo featureguardian
 script:
   - npm install
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: node_js
 node_js:
   - "4.2"
 services: mongodb
-before_script:
-  - mongo featureguardian
+#before_script:
+#  - mongo featureguardian
 script:
   - npm install
   - npm test


### PR DESCRIPTION
Start mongo before build happens so that the integration tests that run against the running sails app are executed and fail the build if there is a regression